### PR TITLE
feat(frontend): add user management screen

### DIFF
--- a/apps/frontend/src/Routes/Layout.tsx
+++ b/apps/frontend/src/Routes/Layout.tsx
@@ -6,7 +6,7 @@ import {
   GridItem
 } from "@chakra-ui/react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { FaRegCalendarCheck, FaUserCircle } from 'react-icons/fa';
+import { FaRegCalendarCheck, FaUserCircle, FaUsers } from 'react-icons/fa';
 import {
   FiCalendar,
   FiHome
@@ -62,6 +62,7 @@ const Layout = () => {
       ])
       setLinkSession([
         { name: `${user?.name}`, icon: FaUserCircle, path: "", color: "pink.300" },
+        { name: "Users", icon: FaUsers, path: paths.users, color: "pink.300" },
         { name: "Log out", icon: FaUserCircle, path: paths.logout, color: "pink.300" },
       ]);
     }

--- a/apps/frontend/src/Routes/Users/Index.tsx
+++ b/apps/frontend/src/Routes/Users/Index.tsx
@@ -1,0 +1,89 @@
+import { useAuth0 } from "@auth0/auth0-react";
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Center,
+  Heading,
+  Spinner,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@chakra-ui/react";
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+const Users = () => {
+  const { getAccessTokenSilently } = useAuth0();
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadUsers = async () => {
+      try {
+        const token = await getAccessTokenSilently();
+        const res = await fetch(`${import.meta.env.VITE_APP_SERVER}/users`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setUsers(data);
+        }
+      } catch (err) {
+        console.error("Failed to load users", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadUsers();
+  }, [getAccessTokenSilently]);
+
+  if (loading) {
+    return (
+      <Center py={10}>
+        <Spinner />
+      </Center>
+    );
+  }
+
+  return (
+    <Box p={6}>
+      <Heading size="md" mb={4}>
+        User Management
+      </Heading>
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>ID</Th>
+            <Th>Name</Th>
+            <Th>Email</Th>
+          </Tr>
+        </Thead>
+       <Tbody>
+          {users.length === 0 ? (
+            <Tr>
+              <Td colSpan={3}>No users found</Td>
+            </Tr>
+          ) : (
+            users.map((user) => (
+              <Tr key={user.id}>
+                <Td>{user.id}</Td>
+                <Td>{user.name}</Td>
+                <Td>{user.email}</Td>
+              </Tr>
+            ))
+          )}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default Users;

--- a/apps/frontend/src/Routes/index.tsx
+++ b/apps/frontend/src/Routes/index.tsx
@@ -14,6 +14,7 @@ import path from "./path";
 import AppointmentManager from "./Appointments/AppointmentManager";
 import CustomChat from "./Messages/CustomChat";
 import Organizer from "./Organizer";
+import Users from "./Users/Index";
 
 const router = createBrowserRouter([
   {
@@ -75,6 +76,12 @@ const router = createBrowserRouter([
         path: path.settings,
         element: <AuthorizedUsers reqAuth={true} />,
         children: [{ path: "", element: <Settings /> }],
+      },
+
+      {
+        path: path.users,
+        element: <AuthorizedUsers reqAuth={true} />,
+        children: [{ path: "", element: <Users /> }],
       },
 
       {

--- a/apps/frontend/src/Routes/path/index.tsx
+++ b/apps/frontend/src/Routes/path/index.tsx
@@ -13,6 +13,7 @@ const paths = {
   assignedAppointments: "/appointments/assigned-appointments",
   organizer: "/organizer",
   settings: "/settings",
+  users: "/users",
   logout: "/logout",
 };
 


### PR DESCRIPTION
## Summary
- add Auth0 user management view with Chakra UI
- wire route and link in header next to session actions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find module 'eslint-scope')

------
https://chatgpt.com/codex/tasks/task_e_68bbe230b8f883268fd42d515cb18285