### PR TITLE
feat: add user upsert registration

### DIFF
--- a/apps/backend/src/index.js
+++ b/apps/backend/src/index.js
@@ -12,6 +12,7 @@ const Routes = require('./routes/index');
 const SMS = require('./routes/sms');
 const Topics = require('./routes/topics.routes');
 const Socket = require('./routes/socket');
+const Users = require('./routes/users.routes');
 const mongoConnect = require('./config/db');
 const setupSocket = require('./config/setupSocket');
 
@@ -47,6 +48,7 @@ app.use((req, res, next) => { req.io = io; next(); });
 app.use("/api",SMS);
 app.use("/api",Routes);
 app.use("/api",Topics);
+app.use("/api",Users);
 app.use("/api/socket.io",Socket);
 app.enable("trust proxy");
 

--- a/apps/backend/src/models/User.js
+++ b/apps/backend/src/models/User.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const UserSchema = new mongoose.Schema(
+  {
+    email: { type: String, required: true, unique: true, index: true },
+    name: { type: String },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('User', UserSchema);

--- a/apps/backend/src/routes/users.routes.js
+++ b/apps/backend/src/routes/users.routes.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const router = express.Router();
+
+const User = require('../models/User');
+const { jwtCheck, attachUserInfo } = require('../middleware/auth');
+
+router.use(jwtCheck);
+router.use(attachUserInfo);
+
+router.post('/users', async (req, res) => {
+  try {
+    const { email, name } = req.body;
+    if (!email) {
+      return res.status(400).json({ error: 'email is required' });
+    }
+
+    const user = await User.findOneAndUpdate(
+      { email },
+      { $setOnInsert: { email, name } },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    ).lean();
+
+    res.json(user);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add User model with unique email
- support registering users via upsert route
- expose user routes on API server

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc211a5de083268605e5baea431a92