### PR TITLE
Add admin user management interface

### DIFF
--- a/apps/backend/src/index.js
+++ b/apps/backend/src/index.js
@@ -44,13 +44,14 @@ const io = setupSocket(server);
 app.use((req, res, next) => { req.io = io; next(); });
 
 // -------- Rutas --------
-app.use("/api",SMS);
+app.use("/api", SMS);
 app.use('/api', require('./routes/secure'));      // ejemplo
 app.use('/api', require('./routes/auth0-sync'));  // webhook de Action
-app.use("/api",Routes);
-+app.use('/api', require('./routes/debug-auth'));  // 👈 añade esto
-app.use("/api",Topics);
-app.use("/api/socket.io",Socket);
+app.use("/api", Routes);
+app.use('/api', require('./routes/debug-auth'));  // 👈 añade esto
+app.use('/api', require('./routes/users.routes'));
+app.use("/api", Topics);
+app.use("/api/socket.io", Socket);
 app.enable("trust proxy");
 
 // -------- Server + Socket.IO --------

--- a/apps/backend/src/models/User/User.js
+++ b/apps/backend/src/models/User/User.js
@@ -26,6 +26,13 @@ const UserSchema = new Schema(
   }
 );
 
+UserSchema.virtual('profile', {
+  ref: 'UserProfile',
+  localField: '_id',
+  foreignField: 'user',
+  justOne: true,
+});
+
 // --- Helper ---
 async function robustUpsert(model, filter, update) {
   try {

--- a/apps/backend/src/models/UserProfile/UserProfile.js
+++ b/apps/backend/src/models/UserProfile/UserProfile.js
@@ -1,0 +1,26 @@
+const { Schema, model, models } = require('mongoose');
+
+const UserProfileSchema = new Schema(
+  {
+    user: { type: Schema.Types.ObjectId, ref: 'User', required: true, unique: true },
+    fullName: { type: String, trim: true },
+    phone: { type: String, trim: true },
+    address: { type: String, trim: true },
+  },
+  {
+    timestamps: true,
+    versionKey: false,
+    toJSON: {
+      virtuals: true,
+      transform(_doc, ret) {
+        ret.id = ret._id;
+        delete ret._id;
+        return ret;
+      },
+    },
+    toObject: { virtuals: true },
+  }
+);
+
+const UserProfile = models.UserProfile || model('UserProfile', UserProfileSchema);
+module.exports = UserProfile;

--- a/apps/backend/src/routes/users.routes.js
+++ b/apps/backend/src/routes/users.routes.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const { requireAuth } = require('../middleware/auth');
+const User = require('../models/User/User');
+const UserProfile = require('../models/UserProfile/UserProfile');
+
+const router = express.Router();
+
+const requireAdmin = [...requireAuth, (req, res, next) => {
+  if (!req.user?.roles?.includes('Admin')) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  next();
+}];
+
+router.get('/users', requireAdmin, async (_req, res) => {
+  const users = await User.find().populate('profile');
+  res.json(users);
+});
+
+router.get('/users/:id', requireAdmin, async (req, res) => {
+  const user = await User.findById(req.params.id).populate('profile');
+  if (!user) return res.status(404).json({ error: 'not_found' });
+  res.json(user);
+});
+
+router.put('/users/:id', requireAdmin, async (req, res) => {
+  const { profile, ...userData } = req.body || {};
+  const user = await User.findByIdAndUpdate(req.params.id, userData, { new: true });
+  if (!user) return res.status(404).json({ error: 'not_found' });
+
+  if (profile) {
+    await UserProfile.findOneAndUpdate(
+      { user: user._id },
+      { $set: profile, $setOnInsert: { user: user._id } },
+      { upsert: true }
+    );
+  }
+
+  const updated = await User.findById(req.params.id).populate('profile');
+  res.json(updated);
+});
+
+module.exports = router;

--- a/apps/frontend/src/Hooks/Access/AuthorizedUsers.tsx
+++ b/apps/frontend/src/Hooks/Access/AuthorizedUsers.tsx
@@ -4,10 +4,11 @@ import { useEffect, useState } from "react";
 
 type Props = {
   reqAuth: boolean;
+  roles?: string[];
 };
 
-function AuthorizedUsers({ reqAuth }: Props) {
-  const { isLoading, isAuthenticated, getAccessTokenSilently, logout } = useAuth0();
+function AuthorizedUsers({ reqAuth, roles }: Props) {
+  const { isLoading, isAuthenticated, getAccessTokenSilently, logout, user } = useAuth0();
   const [validToken, setValidToken] = useState(true);
 
   useEffect(() => {
@@ -29,8 +30,13 @@ function AuthorizedUsers({ reqAuth }: Props) {
     if (reqAuth) checkToken();
   }, [reqAuth, getAccessTokenSilently, logout]);
 
+  const userRoles: string[] = (user && (user as any)["https://letsmarter.com/roles"]) || (user as any)?.roles || [];
+
   if (isLoading) return null;
   if ((!isAuthenticated || !validToken) && reqAuth) {
+    return <Navigate to="/" />;
+  }
+  if (reqAuth && roles && !roles.some((r) => userRoles.includes(r))) {
     return <Navigate to="/" />;
   }
 

--- a/apps/frontend/src/Routes/Layout.tsx
+++ b/apps/frontend/src/Routes/Layout.tsx
@@ -6,7 +6,7 @@ import {
   GridItem
 } from "@chakra-ui/react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { FaRegCalendarCheck, FaUserCircle } from 'react-icons/fa';
+import { FaRegCalendarCheck, FaUserCircle, FaUsers } from 'react-icons/fa';
 import {
   FiCalendar,
   FiHome
@@ -41,6 +41,7 @@ const Layout = () => {
       ]);
       setLinkSession([
         { name: "Sign in", icon: FaUserCircle, path: paths.signin, color: "pink.300" },
+        { name: "Users", icon: FaUsers, path: paths.users, color: "purple.500" },
       ]);
     } else if (!isLoading && isAuthenticated) {
       //{ name: "SMS Center", icon: MdTextsms, path: paths.messages, color: "black.500" },
@@ -61,6 +62,7 @@ const Layout = () => {
          { name: "Settings", icon: IoSettingsOutline, path: paths.settings, color: "black.500" },
       ])
       setLinkSession([
+        { name: "Users", icon: FaUsers, path: paths.users, color: "purple.500" },
         { name: `${user?.name}`, icon: FaUserCircle, path: "", color: "pink.300" },
         { name: "Log out", icon: FaUserCircle, path: paths.logout, color: "pink.300" },
       ]);

--- a/apps/frontend/src/Routes/Users/index.tsx
+++ b/apps/frontend/src/Routes/Users/index.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from 'react';
+import { useApi } from '@/api/client';
+import { Table, Thead, Tbody, Tr, Th, Td, Button, Input } from '@chakra-ui/react';
+
+interface Profile {
+  id: string;
+  fullName?: string;
+  phone?: string;
+  address?: string;
+}
+
+interface User {
+  id: string;
+  email?: string;
+  name?: string;
+  profile?: Profile;
+}
+
+export default function Users() {
+  const api = useApi();
+  const [users, setUsers] = useState<User[]>([]);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [form, setForm] = useState<any>({});
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    const data = await api.get('/api/users');
+    setUsers(data);
+  }
+
+  function startEdit(u: User) {
+    setEditing(u.id);
+    setForm({
+      email: u.email || '',
+      name: u.name || '',
+      fullName: u.profile?.fullName || '',
+      phone: u.profile?.phone || '',
+      address: u.profile?.address || '',
+    });
+  }
+
+  async function save() {
+    await api.put(`/api/users/${editing}`, {
+      email: form.email || null,
+      name: form.name || null,
+      profile: {
+        fullName: form.fullName || null,
+        phone: form.phone || null,
+        address: form.address || null,
+      },
+    });
+    setEditing(null);
+    await load();
+  }
+
+  return (
+    <Table variant="simple">
+      <Thead>
+        <Tr>
+          <Th>Email</Th>
+          <Th>Name</Th>
+          <Th>Full Name</Th>
+          <Th>Phone</Th>
+          <Th>Address</Th>
+          <Th></Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {users.map((u) => (
+          <Tr key={u.id}>
+            <Td>
+              {editing === u.id ? (
+                <Input value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} />
+              ) : (
+                u.email
+              )}
+            </Td>
+            <Td>
+              {editing === u.id ? (
+                <Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
+              ) : (
+                u.name
+              )}
+            </Td>
+            <Td>
+              {editing === u.id ? (
+                <Input value={form.fullName} onChange={(e) => setForm({ ...form, fullName: e.target.value })} />
+              ) : (
+                u.profile?.fullName
+              )}
+            </Td>
+            <Td>
+              {editing === u.id ? (
+                <Input value={form.phone} onChange={(e) => setForm({ ...form, phone: e.target.value })} />
+              ) : (
+                u.profile?.phone
+              )}
+            </Td>
+            <Td>
+              {editing === u.id ? (
+                <Input value={form.address} onChange={(e) => setForm({ ...form, address: e.target.value })} />
+              ) : (
+                u.profile?.address
+              )}
+            </Td>
+            <Td>
+              {editing === u.id ? (
+                <>
+                  <Button size="sm" mr={2} onClick={save}>Save</Button>
+                  <Button size="sm" onClick={() => setEditing(null)}>Cancel</Button>
+                </>
+              ) : (
+                <Button size="sm" onClick={() => startEdit(u)}>Edit</Button>
+              )}
+            </Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  );
+}

--- a/apps/frontend/src/Routes/index.tsx
+++ b/apps/frontend/src/Routes/index.tsx
@@ -14,6 +14,7 @@ import path from "./path";
 import AppointmentManager from "./Appointments/AppointmentManager";
 import CustomChat from "./Messages/CustomChat";
 import Organizer from "./Organizer";
+import Users from "./Users";
 
 const router = createBrowserRouter([
   {
@@ -61,13 +62,13 @@ const router = createBrowserRouter([
            
         ],
       },
-             {
+      {
         path: path.organizer,
         element: <AuthorizedUsers reqAuth={true} />,
         children: [
           { path: "", element: <Organizer /> },
-          
-           
+
+
         ],
       },
 
@@ -75,6 +76,12 @@ const router = createBrowserRouter([
         path: path.settings,
         element: <AuthorizedUsers reqAuth={true} />,
         children: [{ path: "", element: <Settings /> }],
+      },
+
+      {
+        path: path.users,
+        element: <AuthorizedUsers reqAuth={true} roles={["Admin"]} />,
+        children: [{ path: "", element: <Users /> }],
       },
 
       {

--- a/apps/frontend/src/Routes/path/index.tsx
+++ b/apps/frontend/src/Routes/path/index.tsx
@@ -13,6 +13,7 @@ const paths = {
   assignedAppointments: "/appointments/assigned-appointments",
   organizer: "/organizer",
   settings: "/settings",
+  users: "/users",
   logout: "/logout",
 };
 

--- a/apps/frontend/src/api/client.ts
+++ b/apps/frontend/src/api/client.ts
@@ -35,5 +35,15 @@ export function useApi() {
       if (!res.ok) throw new Error(await res.text());
       return res.json();
     },
+    async put(url: string, body: any) {
+      const headers = await authHeaders();
+      const res = await fetch(url, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", ...headers },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      return res.json();
+    },
   };
 }


### PR DESCRIPTION
## Summary
- create `UserProfile` model and connect to `User`
- add admin-only API for listing and updating users with profile data
- build frontend admin interface to view and edit user profiles
- surface a "Users" link next to sign-in for easy access

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` (frontend) *(fails: Cannot find module '/workspace/appointment-platform/apps/frontend/node_modules/eslint-scope/dist/eslint-scope.cjs')*


------
https://chatgpt.com/codex/tasks/task_e_68bd57b4a3208326b38a960f95bc265a